### PR TITLE
Implemented gesture handling on home screen

### DIFF
--- a/app/src/main/java/com/example/android/minutelauncher/AppCard.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/AppCard.kt
@@ -30,16 +30,16 @@ fun AppCard(
 
   Column(
     modifier = Modifier
-        .padding(2.dp)
-        .combinedClickable(onLongClick = {
-            Log.d("APP_CARD", "long press")
-            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-            onLongPress()
-        }) {
-            Log.d("APP_CARD", "click")
-            onClick()
-        }
-        .fillMaxWidth(),
+      .padding(2.dp)
+      .combinedClickable(onLongClick = {
+        Log.d("APP_CARD", "long press")
+        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        onLongPress()
+      }) {
+        Log.d("APP_CARD", "click")
+        onClick()
+      }
+      .fillMaxWidth(),
     horizontalAlignment = Alignment.CenterHorizontally
   ) {
     Text(

--- a/app/src/main/java/com/example/android/minutelauncher/AppList.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/AppList.kt
@@ -42,7 +42,7 @@ fun AppList(
     viewModel.uiEvent.collect { event ->
       when (event) {
         is UiEvent.Search -> {
-          Log.d("APP_LIST", "Search pressed")
+          Log.d("APP_LIST", "Search focused")
           focusRequester.requestFocus()
         }
         is UiEvent.DismissSearch -> {

--- a/app/src/main/java/com/example/android/minutelauncher/Event.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/Event.kt
@@ -10,4 +10,8 @@ sealed class Event {
   object DismissDialog : Event()
   object SearchClicked : Event()
   object DismissSearch : Event()
+  object SwipeLeft : Event()
+  object SwipeRight : Event()
+  object SwipeUp : Event()
+  object SwipeDown : Event()
 }

--- a/app/src/main/java/com/example/android/minutelauncher/Event.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/Event.kt
@@ -11,8 +11,8 @@ sealed class Event {
   object DismissDialog : Event()
   object SearchClicked : Event()
   object DismissSearch : Event()
-  object SwipeLeft : Event()
-  object SwipeRight : Event()
+  data class SwipeLeft(val gestureZone: GestureZone) : Event()
+  data class SwipeRight(val gestureZone: GestureZone) : Event()
   object SwipeUp : Event()
   object SwipeDown : Event()
 }

--- a/app/src/main/java/com/example/android/minutelauncher/Event.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/Event.kt
@@ -5,6 +5,7 @@ sealed class Event {
   data class OpenApplication(val app: UserApp) : Event()
   data class UpdateSearch(val searchTerm: String) : Event()
   object CloseAppsList : Event()
+  object OpenAppsList : Event()
   data class ToggleFavorite(val app: UserApp) : Event()
   data class ShowAppInfo(val app: UserApp) : Event()
   object DismissDialog : Event()

--- a/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
@@ -20,15 +20,13 @@ fun FavoriteApps(
   val totalUsage by viewModel.getTotalUsage()
   val favorites by viewModel.favoriteApps.collectAsState(initial = emptyList())
   Surface(Modifier.fillMaxSize()) {
-    LazyColumn(
+    Column(
       modifier = Modifier.fillMaxSize(),
       verticalArrangement = Arrangement.Bottom,
       horizontalAlignment = Alignment.CenterHorizontally
     ) {
-      item {
-        Text(totalUsage.toTimeUsed())
-      }
-      items(favorites) { app ->
+      Text(totalUsage.toTimeUsed())
+      favorites.forEach { app ->
         val appUsage by viewModel.getUsageForApp(app)
         AppCard(
           app.appTitle,
@@ -36,9 +34,7 @@ fun FavoriteApps(
           { viewModel.onEvent(Event.ShowAppInfo(app)) }
         ) { viewModel.onEvent(Event.OpenApplication(app)) }
       }
-      item {
-        Spacer(modifier = Modifier.height(150.dp)) // TODO: Don't use hardcoded dp value
-      }
+      Spacer(modifier = Modifier.height(150.dp)) // TODO: Don't use hardcoded dp value
     }
   }
 }

--- a/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
@@ -1,24 +1,24 @@
 package com.example.android.minutelauncher
 
-import android.gesture.GestureStore
 import android.util.Log
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.gestures.forEachGesture
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.ripple.LocalRippleTheme
+import androidx.compose.material.ripple.RippleAlpha
+import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import kotlin.math.abs
 
 @Composable
 fun FavoriteApps(
@@ -39,7 +39,8 @@ fun FavoriteApps(
             ) { change, dragAmount ->
               change.consume()
               Log.d("SWIPE", "position: ${change.position}") // height: 0-2399f
-              val gestureZone = if (change.position.y < 2399/2) GestureZone.UPPER else GestureZone.LOWER
+              val gestureZone =
+                if (change.position.y < 2399 / 2) GestureZone.UPPER else GestureZone.LOWER
               gestureHandler(dragAmount, gestureThreshold, gestureZone)?.let { gestureEvent = it }
             }
           }
@@ -48,15 +49,30 @@ fun FavoriteApps(
       horizontalAlignment = Alignment.CenterHorizontally
     ) {
       Text(totalUsage.toTimeUsed())
-      favorites.forEach { app ->
-        val appUsage by viewModel.getUsageForApp(app)
-        AppCard(
-          app.appTitle,
-          appUsage,
-          { viewModel.onEvent(Event.ShowAppInfo(app)) }
-        ) { viewModel.onEvent(Event.OpenApplication(app)) }
+      CompositionLocalProvider(LocalRippleTheme provides ClearRippleTheme) {
+        favorites.forEach { app ->
+          val appUsage by viewModel.getUsageForApp(app)
+          AppCard(
+            app.appTitle,
+            appUsage,
+            { viewModel.onEvent(Event.ShowAppInfo(app)) }
+          ) { viewModel.onEvent(Event.OpenApplication(app)) }
+        }
       }
       Spacer(modifier = Modifier.height(150.dp)) // TODO: Don't use hardcoded dp value
     }
   }
+}
+
+object ClearRippleTheme : RippleTheme {
+  @Composable
+  override fun defaultColor(): Color = Color.Transparent
+
+  @Composable
+  override fun rippleAlpha() = RippleAlpha(
+    draggedAlpha = 0f,
+    focusedAlpha = 0f,
+    hoveredAlpha = 0f,
+    pressedAlpha = 0f
+  )
 }

--- a/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
@@ -1,5 +1,7 @@
 package com.example.android.minutelauncher
 
+import android.util.Log
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,8 +12,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.consumeAllChanges
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import kotlin.math.abs
 
 @Composable
 fun FavoriteApps(
@@ -21,7 +26,21 @@ fun FavoriteApps(
   val favorites by viewModel.favoriteApps.collectAsState(initial = emptyList())
   Surface(Modifier.fillMaxSize()) {
     Column(
-      modifier = Modifier.fillMaxSize(),
+      modifier = Modifier
+        .fillMaxSize()
+        .pointerInput(Unit) {
+          detectDragGestures { change, dragAmount ->
+            change.consume()
+            val threshold = 10f
+            if (abs(dragAmount.y) < threshold) {
+              if (dragAmount.x > threshold) viewModel.onEvent(Event.SwipeRight)
+              else if (dragAmount.x < -threshold) viewModel.onEvent(Event.SwipeLeft)
+            } else {
+              if (dragAmount.y > threshold) viewModel.onEvent(Event.SwipeDown)
+              else if (dragAmount.y < -threshold) viewModel.onEvent(Event.SwipeUp)
+            }
+          }
+        },
       verticalArrangement = Arrangement.Bottom,
       horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/FavoriteApps.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.consumeAllChanges
@@ -24,20 +25,23 @@ fun FavoriteApps(
 ) {
   val totalUsage by viewModel.getTotalUsage()
   val favorites by viewModel.favoriteApps.collectAsState(initial = emptyList())
+  var gestureEvent: Event? = null
   Surface(Modifier.fillMaxSize()) {
     Column(
       modifier = Modifier
         .fillMaxSize()
         .pointerInput(Unit) {
-          detectDragGestures { change, dragAmount ->
+          detectDragGestures(
+            onDragEnd = { gestureEvent?.let { viewModel.onEvent(it) } }
+          ) { change, dragAmount ->
             change.consume()
             val threshold = 10f
             if (abs(dragAmount.y) < threshold) {
-              if (dragAmount.x > threshold) viewModel.onEvent(Event.SwipeRight)
-              else if (dragAmount.x < -threshold) viewModel.onEvent(Event.SwipeLeft)
+              if (dragAmount.x > threshold) gestureEvent = Event.SwipeRight
+              else if (dragAmount.x < -threshold) gestureEvent = Event.SwipeLeft
             } else {
-              if (dragAmount.y > threshold) viewModel.onEvent(Event.SwipeDown)
-              else if (dragAmount.y < -threshold) viewModel.onEvent(Event.SwipeUp)
+              if (dragAmount.y > threshold) gestureEvent = Event.SwipeDown
+              else if (dragAmount.y < -threshold) gestureEvent = Event.SwipeUp
             }
           }
         },

--- a/app/src/main/java/com/example/android/minutelauncher/Gestures.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/Gestures.kt
@@ -1,0 +1,30 @@
+package com.example.android.minutelauncher
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.abs
+
+enum class GestureZone {
+  UPPER, LOWER
+}
+
+fun gestureHandler(dragAmount: Offset, threshold: Float, gestureZone: GestureZone): Event? {
+  var gestureEvent: Event? = null
+  if (abs(dragAmount.x) > abs(dragAmount.y)) {
+    if (abs(dragAmount.x) > threshold) {
+      if (dragAmount.x > 0) {
+        gestureEvent = Event.SwipeRight(gestureZone)
+      } else if (dragAmount.x < 0) {
+        gestureEvent = Event.SwipeLeft(gestureZone)
+      }
+    }
+  } else if (abs(dragAmount.x) < abs(dragAmount.y)) {
+    if (abs(dragAmount.y) > threshold) {
+      if (dragAmount.y > 0) {
+        gestureEvent = Event.SwipeDown
+      } else if (dragAmount.y < 0) {
+        gestureEvent = Event.SwipeUp
+      }
+    }
+  }
+  return gestureEvent
+}

--- a/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
@@ -8,7 +8,9 @@ import android.content.pm.ResolveInfo
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.mutate
@@ -23,6 +25,9 @@ class LauncherViewModel @Inject constructor(
 ) : ViewModel() {
   private val _uiEvent = MutableSharedFlow<UiEvent>()
   val uiEvent = _uiEvent.asSharedFlow()
+    .onSubscription { Log.d("UI_EVENT","New subscriber") }
+    .onCompletion { Log.d("UI_EVENT", "Completed") }
+    .onEach { Log.d("UI_EVENT",it.toString()) }
   private val usageStatsManager by lazy {
     application.applicationContext.getSystemService(
       ComponentActivity.USAGE_STATS_SERVICE
@@ -68,7 +73,10 @@ class LauncherViewModel @Inject constructor(
         updateSearch("")
         sendUiEvent(UiEvent.HideAppsList)
       }
-      is Event.OpenAppsList -> sendUiEvent(UiEvent.ShowAppsList)
+      is Event.OpenAppsList -> {
+        sendUiEvent(UiEvent.ShowAppsList)
+        sendUiEvent(UiEvent.Search)
+      }
       is Event.ToggleFavorite -> {
         dismissDialog()
         toggleFavorite(event.app)

--- a/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
@@ -68,6 +68,7 @@ class LauncherViewModel @Inject constructor(
         updateSearch("")
         sendUiEvent(UiEvent.HideAppsList)
       }
+      is Event.OpenAppsList -> sendUiEvent(UiEvent.ShowAppsList)
       is Event.ToggleFavorite -> {
         dismissDialog()
         toggleFavorite(event.app)
@@ -78,7 +79,7 @@ class LauncherViewModel @Inject constructor(
       is Event.DismissSearch -> sendUiEvent(UiEvent.DismissSearch)
       is Event.SwipeRight -> Unit
       is Event.SwipeLeft -> Unit
-      is Event.SwipeUp -> Unit
+      is Event.SwipeUp -> onEvent(Event.OpenAppsList)
       is Event.SwipeDown -> Unit
     }
   }

--- a/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
@@ -76,6 +76,10 @@ class LauncherViewModel @Inject constructor(
       is Event.DismissDialog -> dismissDialog()
       is Event.SearchClicked -> sendUiEvent(UiEvent.Search)
       is Event.DismissSearch -> sendUiEvent(UiEvent.DismissSearch)
+      is Event.SwipeRight -> Unit
+      is Event.SwipeLeft -> Unit
+      is Event.SwipeUp -> Unit
+      is Event.SwipeDown -> Unit
     }
   }
 

--- a/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/LauncherViewModel.kt
@@ -8,9 +8,7 @@ import android.content.pm.ResolveInfo
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.mutate
@@ -25,9 +23,9 @@ class LauncherViewModel @Inject constructor(
 ) : ViewModel() {
   private val _uiEvent = MutableSharedFlow<UiEvent>()
   val uiEvent = _uiEvent.asSharedFlow()
-    .onSubscription { Log.d("UI_EVENT","New subscriber") }
+    .onSubscription { Log.d("UI_EVENT", "New subscriber") }
     .onCompletion { Log.d("UI_EVENT", "Completed") }
-    .onEach { Log.d("UI_EVENT",it.toString()) }
+    .onEach { Log.d("UI_EVENT", it.toString()) }
   private val usageStatsManager by lazy {
     application.applicationContext.getSystemService(
       ComponentActivity.USAGE_STATS_SERVICE
@@ -88,7 +86,7 @@ class LauncherViewModel @Inject constructor(
       is Event.SwipeRight -> Unit
       is Event.SwipeLeft -> Unit
       is Event.SwipeUp -> onEvent(Event.OpenAppsList)
-      is Event.SwipeDown -> Unit
+      is Event.SwipeDown -> sendUiEvent(UiEvent.ShowNotifications)
     }
   }
 

--- a/app/src/main/java/com/example/android/minutelauncher/MainScreen.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/MainScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
 
+
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun MainScreen(
@@ -21,8 +22,7 @@ fun MainScreen(
       Log.d("MAIN_SCREEN", it.name)
       if (it.name == BottomSheetValue.Expanded.name && !bottomSheetExpanded.value) {
         viewModel.onEvent(Event.SearchClicked)
-      }
-      else viewModel.onEvent(Event.DismissSearch)
+      } else viewModel.onEvent(Event.DismissSearch)
       bottomSheetExpanded.value = it.name == BottomSheetValue.Expanded.name
       true
     }
@@ -39,6 +39,7 @@ fun MainScreen(
         is UiEvent.StartActivity -> {
           mContext.startActivity(event.intent)
         }
+        is UiEvent.ShowNotifications -> Unit
         is UiEvent.HideAppsList -> {
           launch { bottomSheetScaffoldState.bottomSheetState.collapse() }
         }

--- a/app/src/main/java/com/example/android/minutelauncher/MainScreen.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/MainScreen.kt
@@ -5,7 +5,9 @@ import android.widget.Toast
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -17,7 +19,9 @@ fun MainScreen(
   val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(
     bottomSheetState = BottomSheetState(BottomSheetValue.Collapsed) {
       Log.d("MAIN_SCREEN", it.name)
-      if (it.name == BottomSheetValue.Expanded.name && !bottomSheetExpanded.value) viewModel.onEvent(Event.SearchClicked)
+      if (it.name == BottomSheetValue.Expanded.name && !bottomSheetExpanded.value) {
+        viewModel.onEvent(Event.SearchClicked)
+      }
       else viewModel.onEvent(Event.DismissSearch)
       bottomSheetExpanded.value = it.name == BottomSheetValue.Expanded.name
       true
@@ -36,11 +40,10 @@ fun MainScreen(
           mContext.startActivity(event.intent)
         }
         is UiEvent.HideAppsList -> {
-          Log.d("SCREEN", "back pressed")
-          bottomSheetScaffoldState.bottomSheetState.collapse()
+          launch { bottomSheetScaffoldState.bottomSheetState.collapse() }
         }
         is UiEvent.ShowAppsList -> {
-          bottomSheetScaffoldState.bottomSheetState.expand()
+          launch { bottomSheetScaffoldState.bottomSheetState.expand() }
         }
         is UiEvent.ShowAppInfo -> {
           openDialogApp = event.app
@@ -55,6 +58,7 @@ fun MainScreen(
 
   BottomSheetScaffold(
     scaffoldState = bottomSheetScaffoldState,
+    sheetPeekHeight = 0.dp,
     sheetContent = {
       if (openDialogApp != null) {
         AppInfo(

--- a/app/src/main/java/com/example/android/minutelauncher/MainScreen.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/MainScreen.kt
@@ -13,11 +13,13 @@ fun MainScreen(
   viewModel: LauncherViewModel = hiltViewModel()
 ) {
   val mContext = LocalContext.current
+  val bottomSheetExpanded = remember { mutableStateOf(false) }
   val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(
     bottomSheetState = BottomSheetState(BottomSheetValue.Collapsed) {
       Log.d("MAIN_SCREEN", it.name)
-      if (it.name == BottomSheetValue.Expanded.name) viewModel.onEvent(Event.SearchClicked)
+      if (it.name == BottomSheetValue.Expanded.name && !bottomSheetExpanded.value) viewModel.onEvent(Event.SearchClicked)
       else viewModel.onEvent(Event.DismissSearch)
+      bottomSheetExpanded.value = it.name == BottomSheetValue.Expanded.name
       true
     }
   )
@@ -36,6 +38,9 @@ fun MainScreen(
         is UiEvent.HideAppsList -> {
           Log.d("SCREEN", "back pressed")
           bottomSheetScaffoldState.bottomSheetState.collapse()
+        }
+        is UiEvent.ShowAppsList -> {
+          bottomSheetScaffoldState.bottomSheetState.expand()
         }
         is UiEvent.ShowAppInfo -> {
           openDialogApp = event.app

--- a/app/src/main/java/com/example/android/minutelauncher/UiEvent.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/UiEvent.kt
@@ -13,6 +13,7 @@ sealed class UiEvent {
   ) : UiEvent()
 
   object HideAppsList : UiEvent()
+  object ShowAppsList : UiEvent()
 
   data class ShowAppInfo(
     val app: UserApp

--- a/app/src/main/java/com/example/android/minutelauncher/UiEvent.kt
+++ b/app/src/main/java/com/example/android/minutelauncher/UiEvent.kt
@@ -20,6 +20,9 @@ sealed class UiEvent {
   ) : UiEvent()
 
   object DismissDialog : UiEvent()
+
   object Search : UiEvent()
-  object DismissSearch: UiEvent()
+  object DismissSearch : UiEvent()
+
+  object ShowNotifications : UiEvent()
 }


### PR DESCRIPTION
Two GestureZones, Upper and Lower allows four different horizontal gesture shortcuts in total. Swipe down should open notification panel (see [https://github.com/a1vv/Minute-Launcher/issues/11](issue)) and swipe up always opens the apps list.